### PR TITLE
[WIP] add: rinia

### DIFF
--- a/data/members/list.yaml
+++ b/data/members/list.yaml
@@ -203,6 +203,15 @@
     - type: github
       url: https://github.com/Netetra
 
+- name: Rinia
+  avatar: ""
+  role: 超スーパーガチプロ
+  links:
+    - type: twitter
+      url: ""
+    - type: github
+      url: ""
+
 - name: くもことなおこ
   avatar: https://github.com/naoko1010hh.png
   role: 頭のおかしい大天災


### PR DESCRIPTION
りにあのメンバーデータを追加します。

- [ ] GitHub, Twitter のアカウント公開の有無を聞いて、公開する場合はコミットを追加する

りにあ離脱前のメンバーデータではロールが **ガチプロ** でしたが、 **超スーパーガチプロ** だったと思うのでここではそれにしています。

https://github.com/approvers/site-data/pull/66/commits/4f061c8c3dfb4b37f990b8524a557249b01e891b