### PR TITLE
Remove める

### DIFF
--- a/data/members/list.yaml
+++ b/data/members/list.yaml
@@ -367,15 +367,6 @@
     - type: twitter
       url: https://twitter.com/Yorime_yrm
 
-- name: める
-  avatar: https://github.com/m2en.png
-  role: ガチプロ
-  links:
-    - type: twitter
-      url: https://twitter.com/m9eenn
-    - type: github
-      url: https://github.com/m2en
-
 - name: 柚月えふ
   avatar: ""
   role: ガチプロ


### PR DESCRIPTION
鯖から抜けるためメンバーリストから名前を削除しました。

GPG鍵含め、全て破棄しています。

GitHub アカウント自体が変わっているので私が本人である確認がひと目ではできません。このアカウントに [babyrite](https://github.com/lis2a/babyrite) や [citation](https://github.com/lis2a/citation) などのリポジトリがあること [(Forkじゃないので以前の GitHub アカウントにログインできないとリポジトリの移譲はできません)](https://docs.github.com/ja/repositories/creating-and-managing-repositories/transferring-a-repository) などから判断してもらえればと思います。 

Twitterアカウントは今のところ生きているので (検索結果BANなどのシャドウバンはされてますが)、直接本人確認でもいいです。

[approvers/OreOreBot2](https://github.com/approvers/OreOreBot2) , [approvers/haracho.approvers.dev](https://github.com/approvers/haracho.approvers.dev) , [approvers/docs](https://github.com/approvers/docs) はこのPRを持って所有権を放棄するので、消すなりなんなりはお任せします。(私がこの名義のアカウントから何かアクションを起こしたり、メンテはもうできません。)